### PR TITLE
fixed issue with mp3 options

### DIFF
--- a/lib/carrierwave/audio/processor.rb
+++ b/lib/carrierwave/audio/processor.rb
@@ -38,6 +38,7 @@ module CarrierWave
         def convert(source, options={})
           options = DefaultConvertOptions.merge(options)
           format = sanitized_format(options[:output_format])
+          output_options = options[:output_options] || {}
 
           @log = Log.new(options[:logger])
           @log.start!
@@ -50,7 +51,7 @@ module CarrierWave
               input_file_path: source, 
               input_options: input_options, 
               output_file_path: final_filename, 
-              output_options: output_options_for_format(format)
+              output_options: output_options_for_format(format).merge(output_options)
             )
           end
 


### PR DESCRIPTION
fix for an issue when you define compression instead of 128 by default

```
process convert: [output_options: { compression: 320 }]
```
