### PR TITLE
Add conversion to .wav

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ class AudioUploader < CarrierWave::Uploader::Base
 end
 ```
 
-This gem provides two new processors for uploading audio files, `convert` and `watermark`. 
+This gem provides two new processors for uploading audio files, `convert` and `watermark`.
 
 ### Convert
 
@@ -48,9 +48,11 @@ If you'd like to convert from your initially uploaded file-type to a different o
   process :convert => [{output_format:, output_options:}]
 ```
 
-`output_format` - Accepts a symbol. The only currently available option is the default, `:mp3`.
+`output_format` - Accepts a symbol. Available options are: `:mp3` and `:wav`, default option is `:mp3`.
 
 `output_options` - Optional. Sox options for the output file (see [ruby-sox](https://github.com/TMXCredit/ruby-sox) and the [SoX documentation](http://sox.sourceforge.net/sox.pdf)). Defaults to:
+
+* When convert to .mp3:
 
 ```ruby
   {
@@ -58,6 +60,17 @@ If you'd like to convert from your initially uploaded file-type to a different o
     rate: 44100,
     channels: 2,
     compression: 128
+  }
+```
+
+* When convert to .wav:
+
+```ruby
+  {
+    type: output_format.to_s,
+    rate: 44100,
+    channels: 2,
+    bits: 16
   }
 ```
 

--- a/lib/carrierwave/audio.rb
+++ b/lib/carrierwave/audio.rb
@@ -39,6 +39,8 @@ module CarrierWave
       case extension.to_sym
       when :mp3
         "audio/mpeg3"
+      when :wav
+        "audio/vnd.wave"
       end
     end
   end

--- a/lib/carrierwave/audio/processor.rb
+++ b/lib/carrierwave/audio/processor.rb
@@ -26,7 +26,7 @@ module CarrierWave
         #
         #   :output_format => Output file format
         #
-        #     Currently only :mp3 supported
+        #     Currently :mp3 and :wav are supported
         #     Default is :mp3.
         #
         #   :logger => IOStream to log progress to.
@@ -48,9 +48,9 @@ module CarrierWave
           final_filename = tmp_filename(source: source, format: format)
           @log.timed("\nConverting...") do
             convert_file(
-              input_file_path: source, 
-              input_options: input_options, 
-              output_file_path: final_filename, 
+              input_file_path: source,
+              input_options: input_options,
+              output_file_path: final_filename,
               output_options: output_options_for_format(format).merge(output_options)
             )
           end
@@ -96,9 +96,9 @@ module CarrierWave
             converted_watermark = tmp_filename(source: source, format: watermark_ext, prefix: "cnvt_wtmk")
             @log.timed("\nConverting watermarked file to source samplerate of #{source_samplerate}...") do
               convert_file(
-                input_file_path: watermark_file_path, 
-                input_options: watermark_options, 
-                output_file_path: converted_watermark, 
+                input_file_path: watermark_file_path,
+                input_options: watermark_options,
+                output_file_path: converted_watermark,
                 output_options: output_options_for_format(watermark_options[:type]).merge(rate: source_samplerate)
               )
             end
@@ -133,7 +133,7 @@ module CarrierWave
         end
 
         def sanitized_format format
-          supported_formats = [:mp3]
+          supported_formats = %i[mp3 wav]
           if supported_formats.include?(format.to_sym)
             format.to_s
           else
@@ -143,21 +143,19 @@ module CarrierWave
 
         def output_options_for_format format
           shared_options = {
-            channels: 2
+            type: format.to_s,
+            channels: 2,
+            rate: 44100
           }
 
-          if format.to_sym == :mp3
-            {
-              type: format.to_s,
-              rate: 44100,
-              compression: 128
-            }.merge(shared_options)
+          case format.to_sym
+          when :mp3
+            { compression: 128 }
+          when :wav
+            { bits: 16 }
           else
-            {
-              type: format.to_s,
-              rate: 44100
-            }.merge(shared_options)
-          end
+            {}
+          end.merge(shared_options)
         end
 
         # Generate a temporary filename

--- a/lib/carrierwave/audio/processor.rb
+++ b/lib/carrierwave/audio/processor.rb
@@ -78,7 +78,7 @@ module CarrierWave
         #
         def watermark(source, options={})
           options = DefaultWatermarkOptions.merge(options)
-          format = sanitized_format(options[:output_format])
+          format = sanitized_watermark_format(options[:output_format])
           watermark_file_path = options[:watermark_file]
 
           raise ArgumentError.new("No watermark filename given, must be a path to an existing sound file.") unless watermark_file_path
@@ -132,13 +132,16 @@ module CarrierWave
           converter.run
         end
 
-        def sanitized_format format
-          supported_formats = %i[mp3 wav]
+        def sanitized_format format, supported_formats: %i[mp3 wav]
           if supported_formats.include?(format.to_sym)
             format.to_s
           else
             raise ArgumentError.new("Unsupported audio format #{format}. Only conversion to #{supported_formats.to_sentence} allowed.")
           end
+        end
+
+        def sanitized_watermark_format format
+          sanitized_format format, supported_formats: [:mp3]
         end
 
         def output_options_for_format format

--- a/lib/carrierwave/audio/version.rb
+++ b/lib/carrierwave/audio/version.rb
@@ -1,5 +1,5 @@
 module CarrierWave
   module Audio
-    VERSION = '1.0.9'
+    VERSION = '1.0.10'
   end
 end


### PR DESCRIPTION
Hi, I added support for conversion to .wav. 

I didn't touch watermark feature, so watermark still must be .mp3

I manually tested following cases:

* Conversion from `.wav `to `.mp3`
* Conversion from `.mp3` to `.wav`
* Watermarked `.mp3` file